### PR TITLE
Fix Elixir 1.4 warnings

### DIFF
--- a/lib/syslog.ex
+++ b/lib/syslog.ex
@@ -55,7 +55,7 @@ defmodule Logger.Backends.Syslog do
 
     level_num = Logger.Syslog.Utils.level(level)
     pre = :io_lib.format('<~B>~s ~s~p: ', [facility ||| level_num,
-      Logger.Syslog.Utils.iso8601_timestamp(ts), appid, self])
+      Logger.Syslog.Utils.iso8601_timestamp(ts), appid, self()])
 
     packet = [pre, Logger.Formatter.format(format, level, msg, ts, Dict.take(md, metadata))]
     if socket, do: :gen_udp.send(socket, host, port, packet)

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Syslog.Mixfile do
     [app: :syslog,
      version: "0.5.1",
      elixir: ">= 1.0.0",
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
In particular, the warnings around:

"Please use parentheses to remove the ambiguity or change the variable
name" for zero arity function calls.